### PR TITLE
Fix initialization of @!types

### DIFF
--- a/lib/Timezones/ZoneInfo/State.rakumod
+++ b/lib/Timezones/ZoneInfo/State.rakumod
@@ -203,9 +203,9 @@ method new (blob8 $tz, :$name) {
     # it is offset from GMT.
     # TYPES = tranisition time meta data (
     say "  4. Reading associated rules" if $*TZDEBUG;
-    my int8 @types;
+    my int8 @types[$TZ_MAX_TIMES];
     for ^$timecnt {
-        @types.push($tz.read-int8: $pos);
+        @types[$_] = $tz.read-int8: $pos;
         $pos += 1;
     }
     if $*TZDEBUG {


### PR DESCRIPTION
The attribute is shaped, but the initializer array, that gets passed into the `bless` constructor call, is unshapped. This used to somehow evade the check with previous Rakudo releases, but the recent changes got this back door closed.