### PR TITLE
change gmt-offset type to int32

### DIFF
--- a/lib/Timezones/ZoneInfo/Time.rakumod
+++ b/lib/Timezones/ZoneInfo/Time.rakumod
@@ -9,7 +9,7 @@ has int32 $.year       is rw;      #= -∞..∞   (years since 1900; 1910 = 10; 
 has int16 $.weekday    is rw =  0; #=  0..6   (days since Sunday; Monday = 1)
 has int16 $.yearday    is rw =  0; #=  0..365 (Day index in year)
 has int16 $.dst        is rw = -1; #= -1..1   (0 no dst, 1 dst, -1 unknown/automatic)
-has int16 $.gmt-offset is rw =  0; #= -∞..∞   (offset of GMT, positive = east of GMT)
+has int32 $.gmt-offset is rw =  0; #= -∞..∞   (offset of GMT, positive = east of GMT)
 has str   $.tz-abbr    is rw = ""; #=         (Timezone abbreviation NULL AFTER localtime)
 
 multi method gist(::?CLASS:D:) {

--- a/t/100-gmt-offset-overflow.rakutest
+++ b/t/100-gmt-offset-overflow.rakutest
@@ -1,0 +1,19 @@
+use Timezones::ZoneInfo:auth<zef:guifa>;
+use Test;
+plan 4;
+
+# gmt-offset is stored as int16, which overflows for offsets >= 32768 seconds
+# (about 9 hours). Timezones like Australia/Sydney (AEDT, +11h = 39600s) and
+# Pacific/Auckland (NZDT, +13h = 46800s) are affected.
+
+my $epoch = DateTime.new('2024-01-15T12:00:00Z').posix; # January = southern summer
+
+my $sydney = timezone-data('Australia/Sydney');
+my $t = calendar-from-posix($epoch, $sydney);
+is $t.tz-abbr, 'AEDT', 'Sydney abbreviation is AEDT in January';
+is $t.gmt-offset, 39600, 'Sydney gmt-offset is 39600 (UTC+11)';
+
+my $auckland = timezone-data('Pacific/Auckland');
+my $t2 = calendar-from-posix($epoch, $auckland);
+is $t2.tz-abbr, 'NZDT', 'Auckland abbreviation is NZDT in January';
+is $t2.gmt-offset, 46800, 'Auckland gmt-offset is 46800 (UTC+13)';


### PR DESCRIPTION
Hello,

Here's a little change to update the type for offset to fix some cases where it exceeds the range of int32.

thanks
Brian
